### PR TITLE
feat: add logging toggle and unify log handling across Android & iOS

### DIFF
--- a/android/src/main/kotlin/com/ammar/ble/ble_peripheral_plugin/BlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/ammar/ble/ble_peripheral_plugin/BlePeripheralPlugin.kt
@@ -13,501 +13,596 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
 
-class BlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, EventChannel.StreamHandler {
+class BlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandler,
+    EventChannel.StreamHandler {
 
-  companion object {
-    private const val TAG = "BlePeripheralPlugin"
-    private const val MAX_MTU = 512 // Set your desired MTU size
+    companion object {
+        private const val TAG = "BlePeripheralPlugin"
+        private const val MAX_MTU = 512 // Set your desired MTU size
+        private var loggingEnabled = true
 
-  }
 
-  // channels
-  private lateinit var methodChannel: MethodChannel
-  private lateinit var eventChannel: EventChannel
-  private var eventSink: EventChannel.EventSink? = null
-
-  // android context + managers
-  private var appContext: Context? = null
-  private var bluetoothManager: BluetoothManager? = null
-  private var bluetoothAdapter: BluetoothAdapter? = null
-  private var advertiser: BluetoothLeAdvertiser? = null
-  private var scanner: BluetoothLeScanner? = null
-
-  // peripheral (server) state
-  private var gattServer: BluetoothGattServer? = null
-  private var serverServiceUuid: UUID? = null
-  private var serverTxUuid: UUID? = null
-  private var serverRxUuid: UUID? = null
-  private var txCharacteristic: BluetoothGattCharacteristic? = null
-  private var rxCharacteristic: BluetoothGattCharacteristic? = null
-  private val subscribers = mutableSetOf<BluetoothDevice>()
-
-  // central (client) state
-  private var gattClient: BluetoothGatt? = null
-  private var connectedDevice: BluetoothDevice? = null
-
-  override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    appContext = binding.applicationContext
-    methodChannel = MethodChannel(binding.binaryMessenger, "ble_peripheral_plugin/methods")
-    methodChannel.setMethodCallHandler(this)
-    eventChannel = EventChannel(binding.binaryMessenger, "ble_peripheral_plugin/events")
-    eventChannel.setStreamHandler(this)
-
-    bluetoothManager = appContext?.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-    bluetoothAdapter = bluetoothManager?.adapter
-    advertiser = bluetoothAdapter?.bluetoothLeAdvertiser
-    scanner = bluetoothAdapter?.bluetoothLeScanner
-    Log.i(TAG, "Plugin attached")
-  }
-
-  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    stopAll()
-    methodChannel.setMethodCallHandler(null)
-    eventChannel.setStreamHandler(null)
-    Log.i(TAG, "Plugin detached")
-  }
-
-  // EventChannel
-  override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-    eventSink = events
-  }
-
-  override fun onCancel(arguments: Any?) {
-    eventSink = null
-  }
-
-  // MethodChannel
-  override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-    try {
-      when (call.method) {
-        "startPeripheral" -> {
-          val serviceUuid = call.argument<String>("serviceUuid")!!
-          val txUuid = call.argument<String>("txUuid")!!
-          val rxUuid = call.argument<String>("rxUuid")!!
-          startPeripheral(serviceUuid, txUuid, rxUuid)
-          result.success(null)
-        }
-        "stopPeripheral" -> {
-          stopPeripheral()
-          result.success(null)
-        }
-        "sendNotification" -> {
-          val charUuid = call.argument<String>("charUuid")!!
-          val value = call.argument<ByteArray>("value")!!
-          sendNotification(charUuid, value)
-          result.success(null)
-        }
-        "startScan" -> {
-          val serviceUuid = call.argument<String>("serviceUuid")!!
-          startScan(serviceUuid)
-          result.success(null)
-        }
-        "stopScan" -> {
-          stopScan()
-          result.success(null)
-        }
-        "connect" -> {
-          val deviceId = call.argument<String>("deviceId")
-          connect(deviceId)
-          result.success(null)
-        }
-        "disconnect" -> {
-          disconnect()
-          result.success(null)
-        }
-        "writeCharacteristic" -> {
-          val charUuid = call.argument<String>("charUuid")!!
-          val value = call.argument<ByteArray>("value")!!
-          writeCharacteristic(charUuid, value)
-          result.success(null)
-        }
-        "requestMtu" -> {
-          val mtu = call.argument<Int>("mtu") ?: MAX_MTU
-          requestMtu(mtu)
-          result.success(null)
-        }
-        else -> result.notImplemented()
-      }
-    } catch (t: Throwable) {
-      result.error("PLUGIN_ERROR", t.message, null)
-    }
-  }
-
-  // ---------- Peripheral (GATT Server + Advertiser) ----------
-
-  private fun startPeripheral(serviceUuidStr: String, txUuidStr: String, rxUuidStr: String) {
-    stopPeripheral() // cleanup if any
-    serverServiceUuid = UUID.fromString(serviceUuidStr)
-    serverTxUuid = UUID.fromString(txUuidStr)
-    serverRxUuid = UUID.fromString(rxUuidStr)
-
-    // open GATT server
-    gattServer = bluetoothManager?.openGattServer(appContext, gattServerCallback)
-    if (gattServer == null) {
-      sendEvent(mapOf("type" to "error", "message" to "Cannot open GATT server"))
-      return
     }
 
-    // create service and characteristics
-    val service = BluetoothGattService(serverServiceUuid, BluetoothGattService.SERVICE_TYPE_PRIMARY)
-
-    txCharacteristic = BluetoothGattCharacteristic(
-      serverTxUuid,
-      BluetoothGattCharacteristic.PROPERTY_NOTIFY,
-      BluetoothGattCharacteristic.PERMISSION_READ
-    )
-    // CCCD for notifications
-    val cccd = BluetoothGattDescriptor(
-      UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"),
-      BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE
-    )
-    txCharacteristic?.addDescriptor(cccd)
-
-    rxCharacteristic = BluetoothGattCharacteristic(
-      serverRxUuid,
-      BluetoothGattCharacteristic.PROPERTY_WRITE,
-      BluetoothGattCharacteristic.PERMISSION_WRITE
-    )
-
-    service.addCharacteristic(txCharacteristic)
-    service.addCharacteristic(rxCharacteristic)
-    gattServer?.addService(service)
-
-    // start advertising
-    val settings = AdvertiseSettings.Builder()
-      .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
-      .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
-      .setConnectable(true)
-      .build()
-
-    val dataBuilder = AdvertiseData.Builder()
-      .setIncludeDeviceName(false) // keep advertisement small to avoid ADVERTISE_FAILED_DATA_TOO_LARGE
-      .addServiceUuid(ParcelUuid(serverServiceUuid!!))
-
-    val data = dataBuilder.build()
-
-    advertiser?.startAdvertising(settings, data, advertiseCallback)
-    sendEvent(mapOf("type" to "peripheral_started"))
-    Log.i(TAG, "Peripheral started: $serviceUuidStr")
-  }
-
-  private fun stopPeripheral() {
-    try {
-      advertiser?.stopAdvertising(advertiseCallback)
-    } catch (ignored: Exception) {
-    }
-    try {
-      gattServer?.close()
-    } catch (ignored: Exception) {
-    }
-    gattServer = null
-    txCharacteristic = null
-    rxCharacteristic = null
-    subscribers.clear()
-    serverServiceUuid = null
-    serverTxUuid = null
-    serverRxUuid = null
-    sendEvent(mapOf("type" to "peripheral_stopped"))
-  }
-
-  private fun sendNotification(charUuidStr: String, value: ByteArray) {
-    if (gattServer == null) {
-      Log.w(TAG, "No gatt server to notify")
-      return
-    }
-    val charUuid = UUID.fromString(charUuidStr)
-    val characteristic = txCharacteristic
-    if (characteristic == null || characteristic.uuid != charUuid) {
-      Log.w(TAG, "TX characteristic mismatch or missing")
-      return
+    private fun logI(msg: String) {
+        if (loggingEnabled) Log.i(TAG, msg)
     }
 
-    characteristic.value = value
-    // notify all subscribers we tracked via descriptor writes
-    synchronized(subscribers) {
-      for (dev in subscribers) {
+    private fun logW(msg: String) {
+        if (loggingEnabled) Log.w(TAG, msg)
+    }
+
+    private fun logE(msg: String) {
+        if (loggingEnabled) Log.e(TAG, msg)
+    }
+
+    // channels
+    private lateinit var methodChannel: MethodChannel
+    private lateinit var eventChannel: EventChannel
+    private var eventSink: EventChannel.EventSink? = null
+
+    // android context + managers
+    private var appContext: Context? = null
+    private var bluetoothManager: BluetoothManager? = null
+    private var bluetoothAdapter: BluetoothAdapter? = null
+    private var advertiser: BluetoothLeAdvertiser? = null
+    private var scanner: BluetoothLeScanner? = null
+
+    // peripheral (server) state
+    private var gattServer: BluetoothGattServer? = null
+    private var serverServiceUuid: UUID? = null
+    private var serverTxUuid: UUID? = null
+    private var serverRxUuid: UUID? = null
+    private var txCharacteristic: BluetoothGattCharacteristic? = null
+    private var rxCharacteristic: BluetoothGattCharacteristic? = null
+    private val subscribers = mutableSetOf<BluetoothDevice>()
+
+    // central (client) state
+    private var gattClient: BluetoothGatt? = null
+    private var connectedDevice: BluetoothDevice? = null
+
+    override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+        appContext = binding.applicationContext
+        methodChannel = MethodChannel(binding.binaryMessenger, "ble_peripheral_plugin/methods")
+        methodChannel.setMethodCallHandler(this)
+        eventChannel = EventChannel(binding.binaryMessenger, "ble_peripheral_plugin/events")
+        eventChannel.setStreamHandler(this)
+
+        bluetoothManager =
+            appContext?.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        bluetoothAdapter = bluetoothManager?.adapter
+        advertiser = bluetoothAdapter?.bluetoothLeAdvertiser
+        scanner = bluetoothAdapter?.bluetoothLeScanner
+        logi("Plugin attached")
+    }
+
+    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+        stopAll()
+        methodChannel.setMethodCallHandler(null)
+        eventChannel.setStreamHandler(null)
+        logi("Plugin detached")
+    }
+
+    // EventChannel
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+
+    // MethodChannel
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         try {
-          gattServer?.notifyCharacteristicChanged(dev, characteristic, false)
-        } catch (t: Throwable) {
-          Log.w(TAG, "Failed notify to ${dev.address}: ${t.message}")
-        }
-      }
-    }
-  }
+            when (call.method) {
+                "startPeripheral" -> {
+                    val serviceUuid = call.argument<String>("serviceUuid")!!
+                    val txUuid = call.argument<String>("txUuid")!!
+                    val rxUuid = call.argument<String>("rxUuid")!!
+                    startPeripheral(serviceUuid, txUuid, rxUuid)
+                    result.success(null)
+                }
 
-  // GATT Server callback (peripheral)
-  private val gattServerCallback = object : BluetoothGattServerCallback() {
-    override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
-      Log.i(TAG, "Server connection state change: ${device.address} -> $newState")
-      if (newState == BluetoothProfile.STATE_CONNECTED) {
-        sendEvent(mapOf("type" to "server_connected", "deviceId" to device.address, "name" to (device.name ?: "")))
-      } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-        sendEvent(mapOf("type" to "server_disconnected", "deviceId" to device.address))
-        synchronized(subscribers) { subscribers.remove(device) }
-      }
-    }
+                "stopPeripheral" -> {
+                    stopPeripheral()
+                    result.success(null)
+                }
 
-    override fun onCharacteristicWriteRequest(
-      device: BluetoothDevice,
-      requestId: Int,
-      characteristic: BluetoothGattCharacteristic,
-      preparedWrite: Boolean,
-      responseNeeded: Boolean,
-      offset: Int,
-      value: ByteArray
-    ) {
-      Log.i(TAG, "Write request on server char ${characteristic.uuid} from ${device.address}")
-      // send to Flutter as rx
-      sendEvent(mapOf("type" to "rx", "charUuid" to characteristic.uuid.toString(), "value" to value, "deviceId" to device.address))
-      if (responseNeeded) {
-        gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-      }
-    }
+                "sendNotification" -> {
+                    val charUuid = call.argument<String>("charUuid")!!
+                    val value = call.argument<ByteArray>("value")!!
+                    sendNotification(charUuid, value)
+                    result.success(null)
+                }
 
-    override fun onDescriptorWriteRequest(
-      device: BluetoothDevice,
-      requestId: Int,
-      descriptor: BluetoothGattDescriptor,
-      preparedWrite: Boolean,
-      responseNeeded: Boolean,
-      offset: Int,
-      value: ByteArray
-    ) {
-      Log.i(TAG, "Descriptor write on server: ${descriptor.uuid} from ${device.address}")
-      if (descriptor.uuid == UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")) {
-        val enable = value.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
-        if (enable) {
-          synchronized(subscribers) { subscribers.add(device) }
-        } else {
-          synchronized(subscribers) { subscribers.remove(device) }
-        }
-      }
-      if (responseNeeded) {
-        gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-      }
-    }
+                "startScan" -> {
+                    val serviceUuid = call.argument<String>("serviceUuid")!!
+                    startScan(serviceUuid)
+                    result.success(null)
+                }
 
-    // Remove the problematic onMtuChanged method or fix its signature
-    // The correct signature for onMtuChanged in BluetoothGattServerCallback is:
-    // override fun onMtuChanged(device: BluetoothDevice, mtu: Int) { ... }
+                "stopScan" -> {
+                    stopScan()
+                    result.success(null)
+                }
 
-    override fun onMtuChanged(device: BluetoothDevice, mtu: Int) {
-      super.onMtuChanged(device, mtu)
-      Log.i(TAG, "Server MTU changed: ${device.address} -> $mtu")
-      setMtu(device, mtu)
-    }
-  }
-  // Add this method to handle MTU changes in peripheral mode
-  private fun setMtu(device: BluetoothDevice, mtu: Int) {
-    // For peripheral mode, we need to handle MTU in the server callback
-    Log.i(TAG, "MTU changed for ${device.address}: $mtu")
-    sendEvent(mapOf("type" to "mtu_changed", "deviceId" to device.address, "mtu" to mtu))
-  }
-  // Add this method to request MTU
-  @SuppressLint("MissingPermission")
-  private fun requestMtu(mtu: Int) {
-    try {
-      if (gattClient != null) {
-        gattClient?.requestMtu(mtu)
-        Log.i(TAG, "Requesting MTU: $mtu")
-      } else {
-        Log.w(TAG, "Cannot request MTU - GATT client not connected")
-      }
-    } catch (t: Throwable) {
-      Log.e(TAG, "requestMtu error: ${t.message}")
-    }
-  }
-  // Advertise callback
-  private val advertiseCallback = object : AdvertiseCallback() {
-    override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
-      Log.i(TAG, "Advertising started")
-      sendEvent(mapOf("type" to "advertising_started"))
-    }
+                "connect" -> {
+                    val deviceId = call.argument<String>("deviceId")
+                    connect(deviceId)
+                    result.success(null)
+                }
 
-    override fun onStartFailure(errorCode: Int) {
-      Log.e(TAG, "Advertising failed: $errorCode")
-      sendEvent(mapOf("type" to "advertising_failed", "code" to errorCode))
-    }
-  }
+                "disconnect" -> {
+                    disconnect()
+                    result.success(null)
+                }
 
-  // ---------- Central (scanner + gatt client) ----------
+                "writeCharacteristic" -> {
+                    val charUuid = call.argument<String>("charUuid")!!
+                    val value = call.argument<ByteArray>("value")!!
+                    writeCharacteristic(charUuid, value)
+                    result.success(null)
+                }
 
-  @SuppressLint("MissingPermission")
-  private fun startScan(serviceUuidStr: String) {
-    try {
-      val filter = ScanFilter.Builder()
-        .setServiceUuid(ParcelUuid(UUID.fromString(serviceUuidStr)))
-        .build()
-      val settings = ScanSettings.Builder()
-        .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-        .build()
+                "requestMtu" -> {
+                    val mtu = call.argument<Int>("mtu") ?: MAX_MTU
+                    requestMtu(mtu)
+                    result.success(null)
+                }
 
-      scanner?.startScan(listOf(filter), settings, scanCallback)
-      sendEvent(mapOf("type" to "scan_started"))
-    } catch (t: Throwable) {
-      Log.e(TAG, "startScan error: ${t.message}")
-      sendEvent(mapOf("type" to "scan_error", "message" to t.message))
-    }
-  }
+                "enableLogs" -> {
+                    val enable = call.argument<Boolean>("enable") ?: true
+                    loggingEnabled = enable
+                    result.success(null)
+                }
 
-  private fun stopScan() {
-    try {
-      scanner?.stopScan(scanCallback)
-      sendEvent(mapOf("type" to "scan_stopped"))
-    } catch (t: Throwable) {
-      Log.w(TAG, "stopScan error: ${t.message}")
-    }
-  }
-
-  private val scanCallback = object : ScanCallback() {
-    override fun onScanResult(callbackType: Int, result: ScanResult) {
-      val dev = result.device
-      Log.i(TAG, "Scan result: ${dev.address} name=${dev.name ?: ""}")
-      sendEvent(mapOf("type" to "scanResult", "deviceId" to dev.address, "name" to (dev.name ?: "")))
-    }
-
-    override fun onScanFailed(errorCode: Int) {
-      Log.e(TAG, "Scan failed: $errorCode")
-      sendEvent(mapOf("type" to "scan_failed", "code" to errorCode))
-    }
-  }
-
-  @SuppressLint("MissingPermission")
-  private fun connect(deviceId: String?) {
-    if (deviceId == null) return
-    try {
-      val device = bluetoothAdapter?.getRemoteDevice(deviceId) ?: return
-      connectedDevice = device
-      // autoConnect = false
-      gattClient = device.connectGatt(appContext, false, gattClientCallback)
-    } catch (t: Throwable) {
-      Log.e(TAG, "connect error: ${t.message}")
-      sendEvent(mapOf("type" to "connect_error", "message" to t.message))
-    }
-  }
-
-  private fun disconnect() {
-    try {
-      gattClient?.disconnect()
-      gattClient?.close()
-    } catch (t: Throwable) {
-      Log.w(TAG, "disconnect error: ${t.message}")
-    } finally {
-      gattClient = null
-      connectedDevice = null
-      sendEvent(mapOf("type" to "disconnected"))
-    }
-  }
-
-  private val gattClientCallback = object : BluetoothGattCallback() {
-    override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
-      Log.i(TAG, "Client connection state: $newState")
-      if (newState == BluetoothProfile.STATE_CONNECTED) {
-        sendEvent(mapOf("type" to "connected", "deviceId" to (gatt.device?.address ?: "")))
-        // discover services
-        gatt.discoverServices()
-      } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-        sendEvent(mapOf("type" to "disconnected", "deviceId" to (gatt.device?.address ?: "")))
-      }
-    }
-
-    override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
-      Log.i(TAG, "Services discovered")
-      // subscribe to notified characteristic if matches serverTxUuid
-      try {
-        // find characteristic in discovered services
-        val targetCharUuid = serverTxUuid // if connecting to our own server this may be set; otherwise user should use known UUIDs
-        // subscribe to all characteristics that are notify-capable for demo
-        gatt.services.forEach { svc ->
-          svc.characteristics.forEach { c ->
-            if (c.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY != 0) {
-              // enable notification locally
-              gatt.setCharacteristicNotification(c, true)
-              // write descriptor to enable on remote
-              val desc = c.getDescriptor(UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"))
-              desc?.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-              desc?.let { gatt.writeDescriptor(it) }
-              Log.i(TAG, "Subscribed to ${c.uuid}")
+                else -> result.notImplemented()
             }
-          }
+        } catch (t: Throwable) {
+            result.error("PLUGIN_ERROR", t.message, null)
         }
-        gattClient = gatt
-      } catch (t: Throwable) {
-        Log.w(TAG, "Service discover error: ${t.message}")
-      }
     }
 
-    override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
-      Log.i(TAG, "Characteristic changed: ${characteristic.uuid}")
-      sendEvent(mapOf("type" to "notification", "charUuid" to characteristic.uuid.toString(), "value" to characteristic.value))
-    }
+    // ---------- Peripheral (GATT Server + Advertiser) ----------
 
-    override fun onCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
-      Log.i(TAG, "Characteristic write result: ${characteristic.uuid} status=$status")
-      sendEvent(mapOf("type" to "write_result", "charUuid" to characteristic.uuid.toString(), "status" to status))
-    }
+    private fun startPeripheral(serviceUuidStr: String, txUuidStr: String, rxUuidStr: String) {
+        stopPeripheral() // cleanup if any
+        serverServiceUuid = UUID.fromString(serviceUuidStr)
+        serverTxUuid = UUID.fromString(txUuidStr)
+        serverRxUuid = UUID.fromString(rxUuidStr)
 
-    // Remove the problematic onConnectionStateChange method with wrong signature
-    // The correct signature is already implemented above
-
-    override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
-      super.onMtuChanged(gatt, mtu, status)
-      Log.i(TAG, "Client MTU changed: $mtu, status: $status")
-      if (status == BluetoothGatt.GATT_SUCCESS) {
-        sendEvent(mapOf("type" to "mtu_changed", "deviceId" to gatt.device.address, "mtu" to mtu))
-      } else {
-        sendEvent(mapOf("type" to "mtu_change_failed", "deviceId" to gatt.device.address, "status" to status))
-      }
-    }
-  }
-
-  @SuppressLint("MissingPermission")
-  private fun writeCharacteristic(charUuidStr: String, value: ByteArray) {
-    try {
-      val charUuid = UUID.fromString(charUuidStr)
-      val target = gattClient?.services?.firstOrNull { svc -> svc.getCharacteristic(charUuid) != null }?.getCharacteristic(charUuid)
-      if (target == null) {
-        Log.w(TAG, "Target characteristic not found to write: $charUuidStr")
-        sendEvent(mapOf("type" to "write_error", "message" to "Characteristic not found"))
-        return
-      }
-      target.value = value
-      target.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
-      gattClient?.writeCharacteristic(target)
-    } catch (t: Throwable) {
-      Log.e(TAG, "writeCharacteristic error: ${t.message}")
-      sendEvent(mapOf("type" to "write_error", "message" to t.message))
-    }
-  }
-
-  // ---------- helpers ----------
-  private fun sendEvent(payload: Map<String, Any?>) {
-    appContext?.let {
-      if (it is android.app.Activity) {
-        it.runOnUiThread {
-          try {
-            eventSink?.success(payload)
-          } catch (t: Throwable) {
-            Log.w(TAG, "sendEvent error: ${t.message}")
-          }
+        // open GATT server
+        gattServer = bluetoothManager?.openGattServer(appContext, gattServerCallback)
+        if (gattServer == null) {
+            sendEvent(mapOf("type" to "error", "message" to "Cannot open GATT server"))
+            return
         }
-      } else {
-        // fallback: use a Handler if appContext is not Activity
-        android.os.Handler(android.os.Looper.getMainLooper()).post {
-          try {
-            eventSink?.success(payload)
-          } catch (t: Throwable) {
-            Log.w(TAG, "sendEvent error: ${t.message}")
-          }
-        }
-      }
+
+        // create service and characteristics
+        val service =
+            BluetoothGattService(serverServiceUuid, BluetoothGattService.SERVICE_TYPE_PRIMARY)
+
+        txCharacteristic = BluetoothGattCharacteristic(
+            serverTxUuid,
+            BluetoothGattCharacteristic.PROPERTY_NOTIFY,
+            BluetoothGattCharacteristic.PERMISSION_READ
+        )
+        // CCCD for notifications
+        val cccd = BluetoothGattDescriptor(
+            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"),
+            BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE
+        )
+        txCharacteristic?.addDescriptor(cccd)
+
+        rxCharacteristic = BluetoothGattCharacteristic(
+            serverRxUuid,
+            BluetoothGattCharacteristic.PROPERTY_WRITE,
+            BluetoothGattCharacteristic.PERMISSION_WRITE
+        )
+
+        service.addCharacteristic(txCharacteristic)
+        service.addCharacteristic(rxCharacteristic)
+        gattServer?.addService(service)
+
+        // start advertising
+        val settings = AdvertiseSettings.Builder()
+            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+            .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+            .setConnectable(true)
+            .build()
+
+        val dataBuilder = AdvertiseData.Builder()
+            .setIncludeDeviceName(false) // keep advertisement small to avoid ADVERTISE_FAILED_DATA_TOO_LARGE
+            .addServiceUuid(ParcelUuid(serverServiceUuid!!))
+
+        val data = dataBuilder.build()
+
+        advertiser?.startAdvertising(settings, data, advertiseCallback)
+        sendEvent(mapOf("type" to "peripheral_started"))
+        logI("Peripheral started: $serviceUuidStr")
+
     }
-  }
+
+    private fun stopPeripheral() {
+        try {
+            advertiser?.stopAdvertising(advertiseCallback)
+        } catch (ignored: Exception) {
+        }
+        try {
+            gattServer?.close()
+        } catch (ignored: Exception) {
+        }
+        gattServer = null
+        txCharacteristic = null
+        rxCharacteristic = null
+        subscribers.clear()
+        serverServiceUuid = null
+        serverTxUuid = null
+        serverRxUuid = null
+        sendEvent(mapOf("type" to "peripheral_stopped"))
+    }
+
+    private fun sendNotification(charUuidStr: String, value: ByteArray) {
+        if (gattServer == null) {
+            logw("No gatt server to notify")
+            return
+        }
+        val charUuid = UUID.fromString(charUuidStr)
+        val characteristic = txCharacteristic
+        if (characteristic == null || characteristic.uuid != charUuid) {
+            logw("TX characteristic mismatch or missing")
+            return
+        }
+
+        characteristic.value = value
+        // notify all subscribers we tracked via descriptor writes
+        synchronized(subscribers) {
+            for (dev in subscribers) {
+                try {
+                    gattServer?.notifyCharacteristicChanged(dev, characteristic, false)
+                } catch (t: Throwable) {
+                    logw("Failed notify to ${dev.address}: ${t.message}")
+                }
+            }
+        }
+    }
+
+    // GATT Server callback (peripheral)
+    private val gattServerCallback = object : BluetoothGattServerCallback() {
+        override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
+            logi("Server connection state change: ${device.address} -> $newState")
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                sendEvent(
+                    mapOf(
+                        "type" to "server_connected",
+                        "deviceId" to device.address,
+                        "name" to (device.name ?: "")
+                    )
+                )
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                sendEvent(mapOf("type" to "server_disconnected", "deviceId" to device.address))
+                synchronized(subscribers) { subscribers.remove(device) }
+            }
+        }
+
+        override fun onCharacteristicWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            characteristic: BluetoothGattCharacteristic,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray
+        ) {
+            logi("Write request on server char ${characteristic.uuid} from ${device.address}")
+            // send to Flutter as rx
+            sendEvent(
+                mapOf(
+                    "type" to "rx",
+                    "charUuid" to characteristic.uuid.toString(),
+                    "value" to value,
+                    "deviceId" to device.address
+                )
+            )
+            if (responseNeeded) {
+                gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
+            }
+        }
+
+        override fun onDescriptorWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            descriptor: BluetoothGattDescriptor,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray
+        ) {
+            logi("Descriptor write on server: ${descriptor.uuid} from ${device.address}")
+            if (descriptor.uuid == UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")) {
+                val enable = value.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
+                if (enable) {
+                    synchronized(subscribers) { subscribers.add(device) }
+                } else {
+                    synchronized(subscribers) { subscribers.remove(device) }
+                }
+            }
+            if (responseNeeded) {
+                gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
+            }
+        }
+
+        // Remove the problematic onMtuChanged method or fix its signature
+        // The correct signature for onMtuChanged in BluetoothGattServerCallback is:
+        // override fun onMtuChanged(device: BluetoothDevice, mtu: Int) { ... }
+
+        override fun onMtuChanged(device: BluetoothDevice, mtu: Int) {
+            super.onMtuChanged(device, mtu)
+            logi("Server MTU changed: ${device.address} -> $mtu")
+            setMtu(device, mtu)
+        }
+    }
+
+    // Add this method to handle MTU changes in peripheral mode
+    private fun setMtu(device: BluetoothDevice, mtu: Int) {
+        // For peripheral mode, we need to handle MTU in the server callback
+        logi("MTU changed for ${device.address}: $mtu")
+        sendEvent(mapOf("type" to "mtu_changed", "deviceId" to device.address, "mtu" to mtu))
+    }
+
+    // Add this method to request MTU
+    @SuppressLint("MissingPermission")
+    private fun requestMtu(mtu: Int) {
+        try {
+            if (gattClient != null) {
+                gattClient?.requestMtu(mtu)
+                logi("Requesting MTU: $mtu")
+            } else {
+                logw("Cannot request MTU - GATT client not connected")
+            }
+        } catch (t: Throwable) {
+            loge("requestMtu error: ${t.message}")
+        }
+    }
+
+    // Advertise callback
+    private val advertiseCallback = object : AdvertiseCallback() {
+        override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
+            logi("Advertising started")
+            sendEvent(mapOf("type" to "advertising_started"))
+        }
+
+        override fun onStartFailure(errorCode: Int) {
+            loge("Advertising failed: $errorCode")
+            sendEvent(mapOf("type" to "advertising_failed", "code" to errorCode))
+        }
+    }
+
+    // ---------- Central (scanner + gatt client) ----------
+
+    @SuppressLint("MissingPermission")
+    private fun startScan(serviceUuidStr: String) {
+        try {
+            val filter = ScanFilter.Builder()
+                .setServiceUuid(ParcelUuid(UUID.fromString(serviceUuidStr)))
+                .build()
+            val settings = ScanSettings.Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                .build()
+
+            scanner?.startScan(listOf(filter), settings, scanCallback)
+            sendEvent(mapOf("type" to "scan_started"))
+        } catch (t: Throwable) {
+            loge("startScan error: ${t.message}")
+            sendEvent(mapOf("type" to "scan_error", "message" to t.message))
+        }
+    }
+
+    private fun stopScan() {
+        try {
+            scanner?.stopScan(scanCallback)
+            sendEvent(mapOf("type" to "scan_stopped"))
+        } catch (t: Throwable) {
+            logw("stopScan error: ${t.message}")
+        }
+    }
+
+    private val scanCallback = object : ScanCallback() {
+        override fun onScanResult(callbackType: Int, result: ScanResult) {
+            val dev = result.device
+            logi("Scan result: ${dev.address} name=${dev.name ?: ""}")
+            sendEvent(
+                mapOf(
+                    "type" to "scanResult",
+                    "deviceId" to dev.address,
+                    "name" to (dev.name ?: "")
+                )
+            )
+        }
+
+        override fun onScanFailed(errorCode: Int) {
+            loge("Scan failed: $errorCode")
+            sendEvent(mapOf("type" to "scan_failed", "code" to errorCode))
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun connect(deviceId: String?) {
+        if (deviceId == null) return
+        try {
+            val device = bluetoothAdapter?.getRemoteDevice(deviceId) ?: return
+            connectedDevice = device
+            // autoConnect = false
+            gattClient = device.connectGatt(appContext, false, gattClientCallback)
+        } catch (t: Throwable) {
+            loge("connect error: ${t.message}")
+            sendEvent(mapOf("type" to "connect_error", "message" to t.message))
+        }
+    }
+
+    private fun disconnect() {
+        try {
+            gattClient?.disconnect()
+            gattClient?.close()
+        } catch (t: Throwable) {
+            logw("disconnect error: ${t.message}")
+        } finally {
+            gattClient = null
+            connectedDevice = null
+            sendEvent(mapOf("type" to "disconnected"))
+        }
+    }
+
+    private val gattClientCallback = object : BluetoothGattCallback() {
+        override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+            logi("Client connection state: $newState")
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                sendEvent(mapOf("type" to "connected", "deviceId" to (gatt.device?.address ?: "")))
+                // discover services
+                gatt.discoverServices()
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                sendEvent(
+                    mapOf(
+                        "type" to "disconnected",
+                        "deviceId" to (gatt.device?.address ?: "")
+                    )
+                )
+            }
+        }
+
+        override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+            logi("Services discovered")
+            // subscribe to notified characteristic if matches serverTxUuid
+            try {
+                // find characteristic in discovered services
+                val targetCharUuid =
+                    serverTxUuid // if connecting to our own server this may be set; otherwise user should use known UUIDs
+                // subscribe to all characteristics that are notify-capable for demo
+                gatt.services.forEach { svc ->
+                    svc.characteristics.forEach { c ->
+                        if (c.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY != 0) {
+                            // enable notification locally
+                            gatt.setCharacteristicNotification(c, true)
+                            // write descriptor to enable on remote
+                            val desc =
+                                c.getDescriptor(UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"))
+                            desc?.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                            desc?.let { gatt.writeDescriptor(it) }
+                            logi("Subscribed to ${c.uuid}")
+                        }
+                    }
+                }
+                gattClient = gatt
+            } catch (t: Throwable) {
+                logw("Service discover error: ${t.message}")
+            }
+        }
+
+        override fun onCharacteristicChanged(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic
+        ) {
+            logi("Characteristic changed: ${characteristic.uuid}")
+            sendEvent(
+                mapOf(
+                    "type" to "notification",
+                    "charUuid" to characteristic.uuid.toString(),
+                    "value" to characteristic.value
+                )
+            )
+        }
+
+        override fun onCharacteristicWrite(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            status: Int
+        ) {
+            logi("Characteristic write result: ${characteristic.uuid} status=$status")
+            sendEvent(
+                mapOf(
+                    "type" to "write_result",
+                    "charUuid" to characteristic.uuid.toString(),
+                    "status" to status
+                )
+            )
+        }
+
+        // Remove the problematic onConnectionStateChange method with wrong signature
+        // The correct signature is already implemented above
+
+        override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
+            super.onMtuChanged(gatt, mtu, status)
+            logi("Client MTU changed: $mtu, status: $status")
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                sendEvent(
+                    mapOf(
+                        "type" to "mtu_changed",
+                        "deviceId" to gatt.device.address,
+                        "mtu" to mtu
+                    )
+                )
+            } else {
+                sendEvent(
+                    mapOf(
+                        "type" to "mtu_change_failed",
+                        "deviceId" to gatt.device.address,
+                        "status" to status
+                    )
+                )
+            }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun writeCharacteristic(charUuidStr: String, value: ByteArray) {
+        try {
+            val charUuid = UUID.fromString(charUuidStr)
+            val target =
+                gattClient?.services?.firstOrNull { svc -> svc.getCharacteristic(charUuid) != null }
+                    ?.getCharacteristic(charUuid)
+            if (target == null) {
+                logw("Target characteristic not found to write: $charUuidStr")
+                sendEvent(mapOf("type" to "write_error", "message" to "Characteristic not found"))
+                return
+            }
+            target.value = value
+            target.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+            gattClient?.writeCharacteristic(target)
+        } catch (t: Throwable) {
+            loge("writeCharacteristic error: ${t.message}")
+            sendEvent(mapOf("type" to "write_error", "message" to t.message))
+        }
+    }
+
+    // ---------- helpers ----------
+    private fun sendEvent(payload: Map<String, Any?>) {
+        appContext?.let {
+            if (it is android.app.Activity) {
+                it.runOnUiThread {
+                    try {
+                        eventSink?.success(payload)
+                    } catch (t: Throwable) {
+                        logw("sendEvent error: ${t.message}")
+                    }
+                }
+            } else {
+                // fallback: use a Handler if appContext is not Activity
+                android.os.Handler(android.os.Looper.getMainLooper()).post {
+                    try {
+                        eventSink?.success(payload)
+                    } catch (t: Throwable) {
+                        logw("sendEvent error: ${t.message}")
+                    }
+                }
+            }
+        }
+    }
 
 
-  private fun stopAll() {
-    stopScan()
-    disconnect()
-    stopPeripheral()
-  }
+    private fun stopAll() {
+        stopScan()
+        disconnect()
+        stopPeripheral()
+    }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -109,26 +109,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -250,18 +250,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -279,5 +279,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/BlePeripheralPlugin.swift
+++ b/ios/Classes/BlePeripheralPlugin.swift
@@ -105,6 +105,12 @@ public class BlePeripheralPlugin: NSObject, FlutterPlugin, FlutterStreamHandler 
             } else {
                 result(185) // default safe MTU for iOS
             }
+        case "enableLogs":
+            if let args = call.arguments as? [String: Any],
+               let enable = args["enable"] as? Bool {
+                loggingEnabled = enable
+            }
+            result(nil)
 
         default:
             result(FlutterMethodNotImplemented)
@@ -292,4 +298,12 @@ extension BlePeripheralPlugin: CBCentralManagerDelegate, CBPeripheralDelegate {
         guard let value = characteristic.value else { return }
         sendEvent(["type": "notification", "value": value, "deviceId": peripheral.identifier.uuidString])
     }
+    private var loggingEnabled = true
+
+    private func log(_ message: String) {
+        if loggingEnabled {
+            print("[BlePeripheralPlugin] \(message)")
+        }
+    }
+
 }

--- a/lib/ble_peripheral_plugin.dart
+++ b/lib/ble_peripheral_plugin.dart
@@ -75,4 +75,9 @@ class BlePeripheralPlugin {
         .map((event) => Map<String, dynamic>.from(event));
     return _eventStream!;
   }
+
+  static Future<void> enableLogs(bool enable) async {
+    await _method.invokeMethod('enableLogs', {"enable": enable});
+  }
+
 }


### PR DESCRIPTION
- Added `enableLogs` method in Flutter API to control native logging.
- Implemented `loggingEnabled` flag on Android with logI/logW/logE wrappers.
- Integrated `loggingEnabled` flag on iOS with unified log() helper.
- Replaced direct Log/print calls with wrapper functions.
- iOS plugin now mirrors Android’s logging behavior.
